### PR TITLE
fix(webhook): correct customer schema for charge.success event

### DIFF
--- a/src/zod/webhook.ts
+++ b/src/zod/webhook.ts
@@ -467,6 +467,7 @@ export const transactionSuccessful = z.object({
 			fees: z.number().nullable(),
 			customer: customer.omit({
 				international_format_phone: true,
+				id: true,
 			}),
 			authorization: authorization.omit({
 				signature: true,


### PR DESCRIPTION
The Zod schema for the 'charge.success' webhook event expected a 'customer.id' field. However, Paystack's API can omit this field, causing a validation error.

This change updates the 'transactionSuccessful' schema to omit the 'id' field from the nested 'customer' object, aligning it with the behavior of other schemas like 'subscriptionCoreDataSchema' and preventing potential validation errors.