### PR TITLE
fix(zod): use passthrough on all response schemas

### DIFF
--- a/.changeset/ready-crews-arrive.md
+++ b/.changeset/ready-crews-arrive.md
@@ -1,0 +1,5 @@
+---
+"@efobi/paystack": patch
+---
+
+Added passthrough across API responses

--- a/.changeset/ready-crews-arrive.md
+++ b/.changeset/ready-crews-arrive.md
@@ -1,5 +1,0 @@
----
-"@efobi/paystack": patch
----
-
-Added passthrough across API responses

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # @efobi/paystack
 
+## 0.8.5
+
+### Patch Changes
+
+- 1bc6d63: Added passthrough across API responses
+
 ## 0.8.4
 
 ### Patch Changes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@efobi/paystack",
-	"version": "0.8.4",
+	"version": "0.8.5",
 	"description": "A TypeScript SDK for Paystack",
 	"keywords": [
 		"paystack",

--- a/src/zod/miscellaneous.ts
+++ b/src/zod/miscellaneous.ts
@@ -18,52 +18,56 @@ export const miscellaneousListBanksInput = z.object({
 
 export const miscellaneousListBanksSuccess = genericResponse.extend({
 	data: z.array(
-		z.object({
-			name: z.string(),
-			slug: z.string(),
-			code: z.string(),
-			longcode: z.string(),
-			gateway: z.unknown().nullable(),
-			pay_with_bank: z.boolean(),
-			active: z.boolean(),
-			is_deleted: z.boolean(),
-			country: z.string(),
-			currency,
-			type: z.string(),
-			id: z.number(),
-			createdAt: z.iso.datetime().nullable(),
-			updatedAt: z.iso.datetime().nullable(),
-		}),
+		z
+			.object({
+				name: z.string(),
+				slug: z.string(),
+				code: z.string(),
+				longcode: z.string(),
+				gateway: z.unknown().nullable(),
+				pay_with_bank: z.boolean(),
+				active: z.boolean(),
+				is_deleted: z.boolean(),
+				country: z.string(),
+				currency,
+				type: z.string(),
+				id: z.number(),
+				createdAt: z.iso.datetime().nullable(),
+				updatedAt: z.iso.datetime().nullable(),
+			})
+			.passthrough(),
 	),
 });
 
 export const miscellaneousListCountriesSuccess = genericResponse.extend({
 	data: z.array(
-		z.object({
-			id: z.number(),
-			name: z.string(),
-			iso_code: z.string(),
-			default_currency_code: z.string(),
-			integration_defaults: z.object(),
-			relationships: z.object({
-				currency: z.object({
-					type: z.string(),
-					data: z.array(z.string()),
+		z
+			.object({
+				id: z.number(),
+				name: z.string(),
+				iso_code: z.string(),
+				default_currency_code: z.string(),
+				integration_defaults: z.object(),
+				relationships: z.object({
+					currency: z.object({
+						type: z.string(),
+						data: z.array(z.string()),
+					}),
+					integration_feature: z.object({
+						type: z.string(),
+						data: z.array(z.string()),
+					}),
+					integration_type: z.object({
+						type: z.string(),
+						data: z.array(z.string()),
+					}),
+					payment_method: z.object({
+						type: z.string(),
+						data: z.array(z.string()),
+					}),
 				}),
-				integration_feature: z.object({
-					type: z.string(),
-					data: z.array(z.string()),
-				}),
-				integration_type: z.object({
-					type: z.string(),
-					data: z.array(z.string()),
-				}),
-				payment_method: z.object({
-					type: z.string(),
-					data: z.array(z.string()),
-				}),
-			}),
-		}),
+			})
+			.passthrough(),
 	),
 });
 
@@ -73,6 +77,8 @@ export const miscellaneousListStatesInput = z.object({
 
 export const miscellaneousListStatesSuccess = genericResponse.extend({
 	data: z.array(
-		z.object({ name: z.string(), slug: z.string(), abbreviation: z.string() }),
+		z
+			.object({ name: z.string(), slug: z.string(), abbreviation: z.string() })
+			.passthrough(),
 	),
 });

--- a/src/zod/split.ts
+++ b/src/zod/split.ts
@@ -23,26 +23,28 @@ export const splitCreateInput = z.object({
 	bearer_subaccount: z.string(),
 });
 
-export const baseSplitSchema = z.object({
-	id: z.number(),
-	name: z.string(),
-	type,
-	currency,
-	integration: z.number(),
-	domain: z.string(),
-	split_code: z.string(),
-	active: z.boolean(),
-	bearer_type,
-	createdAt: z.iso.datetime(),
-	updatedAt: z.iso.datetime(),
-	is_dynamic: z.boolean(),
-	subaccounts: z.array(
-		z.object({
-			subaccount,
-			share: z.number(),
-		}),
-	),
-});
+export const baseSplitSchema = z
+	.object({
+		id: z.number(),
+		name: z.string(),
+		type,
+		currency,
+		integration: z.number(),
+		domain: z.string(),
+		split_code: z.string(),
+		active: z.boolean(),
+		bearer_type,
+		createdAt: z.iso.datetime(),
+		updatedAt: z.iso.datetime(),
+		is_dynamic: z.boolean(),
+		subaccounts: z.array(
+			z.object({
+				subaccount,
+				share: z.number(),
+			}),
+		),
+	})
+	.passthrough();
 
 export const splitCreateSuccess = genericResponse.extend({
 	data: baseSplitSchema,
@@ -56,18 +58,22 @@ export const splitListInput = genericInput.extend({
 
 export const splitListSuccess = genericResponse.extend({
 	data: z.array(
-		baseSplitSchema.extend({
-			bearer_subaccount: z.string().nullable(),
-			total_subaccounts: z.number(),
-		}),
+		baseSplitSchema
+			.extend({
+				bearer_subaccount: z.string().nullable(),
+				total_subaccounts: z.number(),
+			})
+			.passthrough(),
 	),
 	meta,
 });
 
 export const splitSingleSuccess = genericResponse.extend({
-	data: baseSplitSchema.extend({
-		total_subaccounts: z.number(),
-	}),
+	data: baseSplitSchema
+		.extend({
+			total_subaccounts: z.number(),
+		})
+		.passthrough(),
 });
 
 export const splitUpdateInput = z.object({
@@ -85,20 +91,24 @@ export const splitSubaccountInput = z.object({
 });
 
 export const splitSubaccountUpdateSuccess = genericResponse.extend({
-	data: baseSplitSchema.extend({
-		bearer_subaccount: z.string().nullable(),
-		total_subaccounts: z.number(),
-	}),
+	data: baseSplitSchema
+		.extend({
+			bearer_subaccount: z.string().nullable(),
+			total_subaccounts: z.number(),
+		})
+		.passthrough(),
 });
 
 export const splitSubaccountRemoveInput = splitSubaccountInput.omit({
 	share: true,
 });
 
-export const splitSubaccountRemoveError = genericResponse.extend({
-	meta: z.object({
-		nextStep: z.string().optional(),
-	}),
-	type: z.string().optional(),
-	code: z.string().optional(),
-});
+export const splitSubaccountRemoveError = genericResponse
+	.extend({
+		meta: z.object({
+			nextStep: z.string().optional(),
+		}),
+		type: z.string().optional(),
+		code: z.string().optional(),
+	})
+	.passthrough();

--- a/src/zod/transaction.ts
+++ b/src/zod/transaction.ts
@@ -43,81 +43,89 @@ export const txnInitializeInput = z.object({
 });
 
 export const txnInitializeSuccess = genericResponse.extend({
-	data: z.object({
-		authorization_url: z.url(),
-		access_code: z.string(),
+	data: z
+		.object({
+			authorization_url: z.url(),
+			access_code: z.string(),
+			reference: z.string(),
+		})
+		.passthrough(),
+});
+
+export const transactionShared = z
+	.object({
+		id: z.number(),
+		domain: z.string(),
+		status: z.string(),
 		reference: z.string(),
-	}),
-});
+		receipt_number: z.nullable(z.string()),
+		amount: z.number(),
+		message: z.nullable(z.string()),
+		gateway_response: z.string(),
+		channel: z.string(),
+		currency,
+		ip_address: z.string().nullable(),
+		log: z.nullable(log),
+		fees: z.number().nullable(),
+		fees_split: z.nullable(z.unknown()),
+		authorization: z.nullable(authorization),
+		order_id: z.nullable(z.string()),
+		paidAt: z.iso.datetime().nullable(),
+		createdAt: z.iso.datetime(),
+		requested_amount: z.number(),
+		pos_transaction_data: z.nullable(z.unknown()),
+		connect: z.nullable(z.unknown()),
+	})
+	.passthrough();
 
-export const transactionShared = z.object({
-	id: z.number(),
-	domain: z.string(),
-	status: z.string(),
-	reference: z.string(),
-	receipt_number: z.nullable(z.string()),
-	amount: z.number(),
-	message: z.nullable(z.string()),
-	gateway_response: z.string(),
-	channel: z.string(),
-	currency,
-	ip_address: z.string().nullable(),
-	log: z.nullable(log),
-	fees: z.number().nullable(),
-	fees_split: z.nullable(z.unknown()),
-	authorization: z.nullable(authorization),
-	order_id: z.nullable(z.string()),
-	paidAt: z.iso.datetime().nullable(),
-	createdAt: z.iso.datetime(),
-	requested_amount: z.number(),
-	pos_transaction_data: z.nullable(z.unknown()),
-	connect: z.nullable(z.unknown()),
-});
+const transaction = transactionShared
+	.extend({
+		metadata: z.nullable(metadata),
+		customer,
+		plan: z.nullable(plan),
+		split: z.nullable(baseSplitSchema),
+		subaccount: z.nullable(subaccount),
+		source: z.nullable(
+			z.object({
+				source: z.string(),
+				type: z.string(),
+				identifier: z.nullable(z.string()),
+				entry_point: z.string(),
+			}),
+		),
+	})
+	.passthrough();
 
-const transaction = transactionShared.extend({
-	metadata: z.nullable(metadata),
-	customer,
-	plan: z.nullable(plan),
-	split: z.nullable(baseSplitSchema),
-	subaccount: z.nullable(subaccount),
-	source: z.nullable(
-		z.object({
-			source: z.string(),
-			type: z.string(),
-			identifier: z.nullable(z.string()),
-			entry_point: z.string(),
+const transactionVerify = transactionShared
+	.extend({
+		metadata: z.string(),
+		customer: customer.extend({
+			metadata: z.nullable(z.string()),
+			international_format_phone: z.nullable(z.string()),
 		}),
-	),
-});
-
-const transactionVerify = transactionShared.extend({
-	metadata: z.string(),
-	customer: customer.extend({
-		metadata: z.nullable(z.string()),
-		international_format_phone: z.nullable(z.string()),
-	}),
-	plan: z.nullable(plan),
-	split: z
-		.unknown()
-		.transform((val) =>
-			val && typeof val === "object" && Object.keys(val).length === 0
-				? null
-				: val,
-		)
-		.pipe(z.nullable(baseSplitSchema)),
-	source: z.nullable(z.unknown()),
-	fees_breakdown: z.nullable(z.unknown()),
-	transaction_date: z.string(),
-	plan_object: z.record(z.string(), z.unknown()),
-	subaccount: z
-		.unknown()
-		.transform((val) =>
-			val && typeof val === "object" && Object.keys(val).length === 0
-				? null
-				: val,
-		)
-		.pipe(z.nullable(subaccount)),
-});
+		plan: z.nullable(plan),
+		split: z
+			.unknown()
+			.transform((val) =>
+				val && typeof val === "object" && Object.keys(val).length === 0
+					? null
+					: val,
+			)
+			.pipe(z.nullable(baseSplitSchema)),
+		source: z.nullable(z.unknown()),
+		fees_breakdown: z.nullable(z.unknown()),
+		transaction_date: z.string(),
+		plan_object: z.record(z.string(), z.unknown()),
+		subaccount: z
+			.unknown()
+			.transform((val) =>
+				val && typeof val === "object" && Object.keys(val).length === 0
+					? null
+					: val,
+			)
+			.pipe(z.nullable(subaccount)),
+	})
+	.passthrough();
 
 export const txnVerifySuccess = genericResponse.extend({
 	data: transactionVerify,
@@ -158,52 +166,58 @@ export const txnChargeInput = z.object({
 });
 
 export const txnChargeSuccess = genericResponse.extend({
-	data: z.object({
-		amount: z.number(),
-		currency,
-		transaction_date: z.iso.datetime(),
-		status: z.string(),
-		reference: z.string(),
-		domain: z.string(),
-		metadata: z.nullable(z.string()),
-		gateway_response: z.string(),
-		message: z.nullable(z.string()),
-		channel: z.string(),
-		ip_address: z.nullable(z.ipv4()),
-		log: z.nullable(log),
-		fees: z.number(),
-		authorization,
-		customer,
-		plan: z.nullable(z.number()),
-		id: z.number(),
-	}),
+	data: z
+		.object({
+			amount: z.number(),
+			currency,
+			transaction_date: z.iso.datetime(),
+			status: z.string(),
+			reference: z.string(),
+			domain: z.string(),
+			metadata: z.nullable(z.string()),
+			gateway_response: z.string(),
+			message: z.nullable(z.string()),
+			channel: z.string(),
+			ip_address: z.nullable(z.ipv4()),
+			log: z.nullable(log),
+			fees: z.number(),
+			authorization,
+			customer,
+			plan: z.nullable(z.number()),
+			id: z.number(),
+		})
+		.passthrough(),
 });
 
 export const txnTimelineSuccess = genericResponse.extend({
-	data: z.object({
-		start_time: z.iso.time(),
-		time_spent: z.number(),
-		attempts: z.number(),
-		errors: z.number(),
-		success: z.boolean(),
-		mobile: z.boolean(),
-		input: z.array(z.unknown()),
-		history,
-	}),
+	data: z
+		.object({
+			start_time: z.iso.time(),
+			time_spent: z.number(),
+			attempts: z.number(),
+			errors: z.number(),
+			success: z.boolean(),
+			mobile: z.boolean(),
+			input: z.array(z.unknown()),
+			history,
+		})
+		.passthrough(),
 });
 
 export const txnTotalsSuccess = genericResponse.extend({
-	data: z.object({
-		total_transactions: z.number(),
-		total_volume: z.number(),
-		total_volume_by_currency: z.array(
-			z.object({ currency, amount: z.number() }),
-		),
-		pending_transfers: z.number(),
-		pending_transfers_by_currency: z.array(
-			z.object({ currency, amount: z.number() }),
-		),
-	}),
+	data: z
+		.object({
+			total_transactions: z.number(),
+			total_volume: z.number(),
+			total_volume_by_currency: z.array(
+				z.object({ currency, amount: z.number() }),
+			),
+			pending_transfers: z.number(),
+			pending_transfers_by_currency: z.array(
+				z.object({ currency, amount: z.number() }),
+			),
+		})
+		.passthrough(),
 });
 
 export const txnExportInput = genericInput.extend({
@@ -217,10 +231,12 @@ export const txnExportInput = genericInput.extend({
 });
 
 export const txnExportSuccess = genericResponse.extend({
-	data: z.object({
-		path: z.url(),
-		expiresAt: z.iso.datetime(),
-	}),
+	data: z
+		.object({
+			path: z.url(),
+			expiresAt: z.iso.datetime(),
+		})
+		.passthrough(),
 });
 
 export const txnPartialDebitInput = z.object({
@@ -233,7 +249,9 @@ export const txnPartialDebitInput = z.object({
 });
 
 export const txnPartialDebitSuccess = genericResponse.extend({
-	data: txnChargeSuccess.shape.data.extend({
-		requested_amount: z.number(),
-	}),
+	data: txnChargeSuccess.shape.data
+		.extend({
+			requested_amount: z.number(),
+		})
+		.passthrough(),
 });

--- a/src/zod/verification.ts
+++ b/src/zod/verification.ts
@@ -7,10 +7,12 @@ export const verificationResolveAccountInput = z.object({
 });
 
 export const verificationResolveAccountSuccess = genericResponse.extend({
-	data: z.object({
-		account_number: z.string(),
-		account_name: z.string(),
-	}),
+	data: z
+		.object({
+			account_number: z.string(),
+			account_name: z.string(),
+		})
+		.passthrough(),
 });
 
 export const verificationValidateAccountInput = z.object({
@@ -28,10 +30,12 @@ export const verificationValidateAccountInput = z.object({
 });
 
 export const verificationValidateAccountResponse = genericResponse.extend({
-	data: z.object({
-		verified: z.boolean(),
-		verificationMessage: z.string(),
-	}),
+	data: z
+		.object({
+			verified: z.boolean(),
+			verificationMessage: z.string(),
+		})
+		.passthrough(),
 });
 
 export const verificationResolveCardBinInput = z.object({
@@ -39,14 +43,16 @@ export const verificationResolveCardBinInput = z.object({
 });
 
 export const verificationResolveCardBinSuccess = genericResponse.extend({
-	data: z.object({
-		bin: z.string(),
-		brand: z.string(),
-		sub_brand: z.string(),
-		country_code: z.string(),
-		country_name: z.string(),
-		card_type: z.string(),
-		bank: z.string(),
-		linked_bank_id: z.number(),
-	}),
+	data: z
+		.object({
+			bin: z.string(),
+			brand: z.string(),
+			sub_brand: z.string(),
+			country_code: z.string(),
+			country_name: z.string(),
+			card_type: z.string(),
+			bank: z.string(),
+			linked_bank_id: z.number(),
+		})
+		.passthrough(),
 });

--- a/src/zod/virtual.ts
+++ b/src/zod/virtual.ts
@@ -11,40 +11,46 @@ export const virtualAccountCreateInput = z.object({
 	phone: z.string().optional(),
 });
 
-export const virtualAccountAssignmentSchema = z.object({
-	integration: z.number(),
-	assignee_id: z.number(),
-	assignee_type: z.string(),
-	expired: z.boolean(),
-	account_type: z.string(),
-	assigned_at: z.iso.datetime(),
-});
+export const virtualAccountAssignmentSchema = z
+	.object({
+		integration: z.number(),
+		assignee_id: z.number(),
+		assignee_type: z.string(),
+		expired: z.boolean(),
+		account_type: z.string(),
+		assigned_at: z.iso.datetime(),
+	})
+	.passthrough();
 
-export const virtualAccountBaseSchema = z.object({
-	bank: z.object({
-		name: z.string(),
+export const virtualAccountBaseSchema = z
+	.object({
+		bank: z.object({
+			name: z.string(),
+			id: z.number(),
+			slug: z.string(),
+		}),
+		account_name: z.string(),
+		account_number: z.string(),
+		assigned: z.boolean(),
+		currency,
+		metadata: z.nullable(metadata),
+		active: z.boolean(),
 		id: z.number(),
-		slug: z.string(),
-	}),
-	account_name: z.string(),
-	account_number: z.string(),
-	assigned: z.boolean(),
-	currency,
-	metadata: z.nullable(metadata),
-	active: z.boolean(),
-	id: z.number(),
-	created_at: z.iso.datetime(),
-	updated_at: z.iso.datetime(),
-});
+		created_at: z.iso.datetime(),
+		updated_at: z.iso.datetime(),
+	})
+	.passthrough();
 
 export const virtualAccountCreateSuccess = genericResponse.extend({
-	data: virtualAccountBaseSchema.extend({
-		assignment: virtualAccountAssignmentSchema,
-		customer: customer.omit({
-			metadata: true,
-			international_format_phone: true,
-		}),
-	}),
+	data: virtualAccountBaseSchema
+		.extend({
+			assignment: virtualAccountAssignmentSchema,
+			customer: customer.omit({
+				metadata: true,
+				international_format_phone: true,
+			}),
+		})
+		.passthrough(),
 });
 
 export const virtualAccountAssignInput = z.object({
@@ -70,23 +76,27 @@ export const virtualAccountListInput = z.object({
 
 export const virtualAccountListSuccess = genericResponse.extend({
 	data: z.array(
-		virtualAccountBaseSchema.extend({
-			assignment: virtualAccountAssignmentSchema,
-			customer: customer.omit({
-				metadata: true,
-				international_format_phone: true,
-			}),
-		}),
+		virtualAccountBaseSchema
+			.extend({
+				assignment: virtualAccountAssignmentSchema,
+				customer: customer.omit({
+					metadata: true,
+					international_format_phone: true,
+				}),
+			})
+			.passthrough(),
 	),
 	meta,
 });
 
 export const virtualAccountFetchSuccess = genericResponse.extend({
-	data: virtualAccountBaseSchema.extend({
-		assignment: virtualAccountAssignmentSchema,
-		customer,
-		split_config: z.string(),
-	}),
+	data: virtualAccountBaseSchema
+		.extend({
+			assignment: virtualAccountAssignmentSchema,
+			customer,
+			split_config: z.string(),
+		})
+		.passthrough(),
 });
 
 export const virtualAccountRequeryInput = z.object({
@@ -96,11 +106,13 @@ export const virtualAccountRequeryInput = z.object({
 });
 
 export const virtualAccountDeleteSuccess = genericResponse.extend({
-	data: virtualAccountBaseSchema.extend({
-		assignment: virtualAccountAssignmentSchema.omit({ expired: true }),
-		customer,
-		split_config: z.string(),
-	}),
+	data: virtualAccountBaseSchema
+		.extend({
+			assignment: virtualAccountAssignmentSchema.omit({ expired: true }),
+			customer,
+			split_config: z.string(),
+		})
+		.passthrough(),
 });
 
 export const virtualAccountAddSplitInput = z.object({
@@ -111,17 +123,19 @@ export const virtualAccountAddSplitInput = z.object({
 });
 
 export const virtualAccountAddSplitSuccess = genericResponse.extend({
-	data: virtualAccountBaseSchema.extend({
-		assignment: virtualAccountAssignmentSchema.extend({
-			expired_at: z.iso.datetime().nullable(),
-		}),
-		customer: customer.omit({
-			international_format_phone: true,
-		}),
-		split_config: z.object({
-			split_code: z.string(),
-		}),
-	}),
+	data: virtualAccountBaseSchema
+		.extend({
+			assignment: virtualAccountAssignmentSchema.extend({
+				expired_at: z.iso.datetime().nullable(),
+			}),
+			customer: customer.omit({
+				international_format_phone: true,
+			}),
+			split_config: z.object({
+				split_code: z.string(),
+			}),
+		})
+		.passthrough(),
 });
 
 export const virtualAccountRemoveSplitInput = virtualAccountRequeryInput.omit({
@@ -130,26 +144,30 @@ export const virtualAccountRemoveSplitInput = virtualAccountRequeryInput.omit({
 });
 
 export const virtualAccountRemoveSplitSuccess = genericResponse.extend({
-	data: z.object({
-		id: z.number(),
-		split_config: z.object(),
-		account_name: z.string(),
-		account_number: z.string(),
-		currency,
-		assigned: z.boolean(),
-		active: z.boolean(),
-		created_at: z.iso.datetime(),
-		updated_at: z.iso.datetime(),
-	}),
+	data: z
+		.object({
+			id: z.number(),
+			split_config: z.object(),
+			account_name: z.string(),
+			account_number: z.string(),
+			currency,
+			assigned: z.boolean(),
+			active: z.boolean(),
+			created_at: z.iso.datetime(),
+			updated_at: z.iso.datetime(),
+		})
+		.passthrough(),
 });
 
 export const fetchBanksSuccess = genericResponse.extend({
 	data: z.array(
-		z.object({
-			provider_slug: z.string(),
-			bank_id: z.number(),
-			bank_name: z.string(),
-			id: z.number(),
-		}),
+		z
+			.object({
+				provider_slug: z.string(),
+				bank_id: z.number(),
+				bank_name: z.string(),
+				id: z.number(),
+			})
+			.passthrough(),
 	),
 });

--- a/src/zod/webhook.ts
+++ b/src/zod/webhook.ts
@@ -14,384 +14,78 @@ import {
 	virtualAccountBaseSchema,
 } from "./virtual";
 
-const disputeTransactionSchema = z.object({
-	id: z.number(),
-	domain: z.string(),
-	status: z.string(),
-	reference: z.string(),
-	amount: z.number(),
-	message: z.string().nullable(),
-	gateway_response: z.string(),
-	paid_at: z.iso.datetime(),
-	created_at: z.iso.datetime(),
-	channel: z.string(),
-	currency,
-	ip_address: z.ipv4().nullable(),
-	metadata: z.string(),
-	log: z.nullable(log),
-	fees: z.number(),
-	fees_split: z.unknown().nullable(),
-	authorization: authorization.optional(),
-	customer: customer.pick({
-		international_format_phone: true,
-	}),
-	plan,
-	subaccount: subaccount.optional(),
-	split: z.object().optional(),
-	order_id: z.string().nullable(),
-	paidAt: z.iso.datetime(),
-	requested_amount: z.number(),
-	pos_transaction_data: z.unknown().nullable(),
-});
-
-const disputeDataSchema = z.object({
-	id: z.number(),
-	refund_amount: z.number(),
-	currency,
-	status: z.string(),
-	resolution: z.unknown().nullable(),
-	domain: z.string(),
-	transaction: disputeTransactionSchema,
-	transaction_reference: z.string().nullable(),
-	category: z.string(),
-	customer,
-	bin: z.string(),
-	last4: z.string(),
-	dueAt: z.iso.datetime(),
-	resolvedAt: z.iso.datetime().nullable(),
-	evidence: z.unknown().nullable(),
-	attachments: z.unknown().nullable(),
-	note: z.unknown().nullable(),
-	history: z.array(
-		z.object({
-			status: z.string(),
-			by: z.email(),
-			created_at: z.iso.datetime(),
-		}),
-	),
-	messages: z.array(
-		z.object({
-			sender: z.email(),
-			body: z.string(),
-			created_at: z.iso.datetime(),
-		}),
-	),
-	created_at: z.iso.datetime(),
-	updated_at: z.iso.datetime(),
-});
-
-const invoiceSubscriptionSchema = z.object({
-	status: z.string(),
-	subscription_code: z.string().startsWith("SUB_"),
-	email_token: z.string(),
-	amount: z.number(),
-	cron_expression: z.string(),
-	next_payment_date: z.iso.datetime(),
-	open_invoice: z.unknown().nullable(),
-});
-
-const invoiceSuccessTransactionSchema = z.object({
-	reference: z.uuid(),
-	status: z.string(),
-	amount: z.number(),
-	currency,
-});
-
-const invoiceDataBaseSchema = z.object({
-	domain: z.string(),
-	invoice_code: z.string().startsWith("INV_"),
-	amount: z.number(),
-	period_start: z.iso.datetime(),
-	period_end: z.iso.datetime(),
-	status: z.string(),
-	paid: z.boolean(),
-	paid_at: z.iso.datetime().nullable(),
-	description: z.string().nullable(),
-	authorization,
-	subscription: invoiceSubscriptionSchema,
-	customer: customer.omit({
-		international_format_phone: true,
-	}),
-});
-
-const paymentRequestDataSchema = z.object({
-	id: z.number(),
-	domain: z.string(),
-	amount: z.number(),
-	currency,
-	due_date: z.iso.datetime().nullable(),
-	has_invoice: z.boolean(),
-	invoice_number: z.string().nullable(),
-	description: z.string().nullable(),
-	pdf_url: z.url().nullable(),
-	line_items: z.array(z.unknown()),
-	tax: z.array(z.unknown()),
-	request_code: z.string().startsWith("PRQ_"),
-	status: z.string(),
-	paid: z.boolean(),
-	paid_at: z.iso.datetime().nullable(),
-	metadata: z.nullable(metadata),
-	notifications: z.array(
-		z.object({
-			sent_at: z.iso.datetime(),
-			channel: z.string(),
-		}),
-	),
-	offline_reference: z.string().nullable(),
-	customer: z.number(),
-	created_at: z.iso.datetime(),
-});
-
-const refundDataBaseSchema = z.object({
-	status: z.string(),
-	transaction_reference: z.string(),
-	amount: z.number(),
-	currency,
-	processor: z.string(),
-	customer: customer.pick({
-		first_name: true,
-		last_name: true,
-		email: true,
-	}),
-	integration: z.number(),
-	domain: z.string(),
-});
-
-const refundPendingOrProcessingDataSchema = refundDataBaseSchema.extend({
-	refund_reference: z.string().startsWith("TRF_").nullable(),
-});
-
-const refundFailedOrProcessedDataSchema = refundDataBaseSchema.extend({
-	refund_reference: z.string().startsWith("TRF_"),
-});
-
-const subscriptionCoreDataSchema = z.object({
-	domain: z.string(),
-	status: z.string(),
-	subscription_code: z.string().startsWith("SUB_"),
-	amount: z.number(),
-	cron_expression: z.string(),
-	next_payment_date: z.iso.datetime(),
-	open_invoice: z.unknown().nullable(),
-	plan,
-	authorization: authorization.omit({
-		reusable: true,
-		signature: true,
-	}),
-	customer: customer.omit({
-		international_format_phone: true,
-		id: true,
-	}),
-	created_at: z.iso.datetime(),
-});
-
-const transferDataBaseSchema = z.object({
-	amount: z.number(),
-	currency,
-	domain: z.string(),
-	failures: z.unknown().nullable(),
-	id: z.number(),
-	integration: z.object({
-		id: z.number(),
-		is_live: z.boolean(),
-		business_name: z.string(),
-	}),
-	reason: z.string(),
-	reference: z.string(),
-	source: z.string(),
-	source_details: z.unknown().nullable(),
-	status: z.string(),
-	titan_code: z.string().nullable(),
-	transfer_code: z.string().startsWith("TRF_"),
-	transferred_at: z.iso.datetime().nullable(),
-	session: z.object({
-		provider: z.string().nullable(),
-		id: z.string().nullable(),
-	}),
-	created_at: z.iso.datetime(),
-	updated_at: z.iso.datetime(),
-});
-
-const baseRecipientSchema = z.object({
-	active: z.boolean(),
-	currency,
-	description: z.string(),
-	domain: z.string(),
-	email: z.email().nullable(),
-	id: z.number(),
-	integration: z.number(),
-	metadata: z.nullable(metadata),
-	name: z.string(),
-	recipient_code: z.string().startsWith("RCP_"),
-	type: z.string(),
-	is_deleted: z.boolean(),
-	created_at: z.iso.datetime(),
-	updated_at: z.iso.datetime(),
-});
-
-const transferSuccessRecipientSchema = baseRecipientSchema.extend({
-	details: z.object({
-		account_number: z.string(),
-		account_name: z.string().nullable(),
-		bank_code: z.string(),
-		bank_name: z.string(),
-	}),
-});
-
-const transferFailedOrReversedRecipientSchema = baseRecipientSchema.extend({
-	details: z.object({
-		account_number: z.string(),
-		account_name: z.string().nullable(),
-		bank_code: z.string(),
-		bank_name: z.string(),
-		authorization_code: z.string().startsWith("AUTH_").nullable(),
-	}),
-});
-
-const identificationBaseSchema = z.object({
-	country: z.enum(["NG", "GH"]),
-	type: z.string(),
-});
-
-const customerDataBaseSchema = z.object({
-	customer_id: z.string(),
-	customer_code: z.string().startsWith("CUS_"),
-	email: z.email(),
-});
-
-export const customerIdFail = z.object({
-	event: z.literal("customeridentification.failed"),
-	data: customerDataBaseSchema.extend({
-		identification: identificationBaseSchema.extend({
-			bvn: z.string(),
-			account_number: z.string(),
-			bank_code: z.string(),
-		}),
-	}),
-	reason: z.string(),
-});
-
-export const customerIdSuccess = z.object({
-	event: z.literal("customeridentification.success"),
-	data: customerDataBaseSchema.extend({
-		identification: identificationBaseSchema.extend({
-			value: z.string(),
-		}),
-	}),
-});
-
-export const disputeCreated = z.object({
-	event: z.literal("charge.dispute.create"),
-	data: disputeDataSchema,
-});
-
-export const disputeReminder = z.object({
-	event: z.literal("charge.dispute.remind"),
-	data: disputeDataSchema,
-});
-
-export const disputeResolved = z.object({
-	event: z.literal("charge.dispute.resolve"),
-	data: disputeDataSchema,
-});
-
-export const dedicatedAccountAssignFail = z.object({
-	event: z.literal("dedicatedaccount.assign.failed"),
-	data: z.object({
-		customer,
-		dedicated_account: z.unknown().nullable(),
-		identification: z.object({
-			status: z.string(),
-		}),
-	}),
-});
-
-export const dedicatedAccountAssignSuccess = z.object({
-	event: z.literal("dedicatedaccount.assign.success"),
-	data: z.object({
-		customer,
-		dedicated_account: virtualAccountBaseSchema,
-		assignment: virtualAccountAssignmentSchema.extend({
-			expired_at: z.iso.datetime().nullable(),
-		}),
-	}),
-	identification: z.object({
-		status: z.string(),
-	}),
-});
-
-export const invoiceCreate = z.object({
-	event: z.literal("invoice.create"),
-	data: invoiceDataBaseSchema.extend({
-		transaction: invoiceSuccessTransactionSchema,
-		created_at: z.iso.datetime(),
-	}),
-});
-
-export const invoiceFail = z.object({
-	event: z.literal("invoice.payment_failed"),
-	data: invoiceDataBaseSchema.extend({
-		transaction: invoiceSuccessTransactionSchema.partial(),
-		created_at: z.iso.datetime(),
-	}),
-});
-
-export const invoiceUpdate = z.object({
-	event: z.literal("invoice.update"),
-	data: invoiceDataBaseSchema.extend({
-		transaction: invoiceSuccessTransactionSchema,
-	}),
-});
-
-export const paymentRequestPending = z.object({
-	event: z.literal("paymentrequest.pending"),
-	data: paymentRequestDataSchema,
-});
-
-export const paymentRequestSuccess = z.object({
-	event: z.literal("paymentrequest.success"),
-	data: paymentRequestDataSchema,
-});
-
-export const refundFailed = z.object({
-	event: z.literal("refund.failed"),
-	data: refundFailedOrProcessedDataSchema,
-});
-
-export const refundPending = z.object({
-	event: z.literal("refund.pending"),
-	data: refundPendingOrProcessingDataSchema,
-});
-
-export const refundProcessed = z.object({
-	event: z.literal("refund.processed"),
-	data: refundFailedOrProcessedDataSchema,
-});
-
-export const refundProcessing = z.object({
-	event: z.literal("refund.processing"),
-	data: refundPendingOrProcessingDataSchema,
-});
-
-export const subscriptionCreate = z.object({
-	event: z.literal("subscription.create"),
-	data: subscriptionCoreDataSchema.extend({
-		createdAt: z.iso.datetime(),
-	}),
-});
-
-export const subscriptionDisabled = z.object({
-	event: z.literal("subscription.disable"),
-	data: subscriptionCoreDataSchema.extend({
-		email_token: z.string(),
-	}),
-});
-
-export const subscriptionNotRenewed = z.object({
-	event: z.literal("subscription.not_renew"),
-	data: z.object({
+const disputeTransactionSchema = z
+	.object({
 		id: z.number(),
 		domain: z.string(),
+		status: z.string(),
+		reference: z.string(),
+		amount: z.number(),
+		message: z.string().nullable(),
+		gateway_response: z.string(),
+		paid_at: z.iso.datetime(),
+		created_at: z.iso.datetime(),
+		channel: z.string(),
+		currency,
+		ip_address: z.ipv4().nullable(),
+		metadata: z.string(),
+		log: z.nullable(log),
+		fees: z.number(),
+		fees_split: z.unknown().nullable(),
+		authorization: authorization.optional(),
+		customer: customer.pick({
+			international_format_phone: true,
+		}),
+		plan,
+		subaccount: subaccount.optional(),
+		split: z.object().optional(),
+		order_id: z.string().nullable(),
+		paidAt: z.iso.datetime(),
+		requested_amount: z.number(),
+		pos_transaction_data: z.unknown().nullable(),
+	})
+	.passthrough();
+
+const disputeDataSchema = z
+	.object({
+		id: z.number(),
+		refund_amount: z.number(),
+		currency,
+		status: z.string(),
+		resolution: z.unknown().nullable(),
+		domain: z.string(),
+		transaction: disputeTransactionSchema,
+		transaction_reference: z.string().nullable(),
+		category: z.string(),
+		customer,
+		bin: z.string(),
+		last4: z.string(),
+		dueAt: z.iso.datetime(),
+		resolvedAt: z.iso.datetime().nullable(),
+		evidence: z.unknown().nullable(),
+		attachments: z.unknown().nullable(),
+		note: z.unknown().nullable(),
+		history: z.array(
+			z.object({
+				status: z.string(),
+				by: z.email(),
+				created_at: z.iso.datetime(),
+			}),
+		),
+		messages: z.array(
+			z.object({
+				sender: z.email(),
+				body: z.string(),
+				created_at: z.iso.datetime(),
+			}),
+		),
+		created_at: z.iso.datetime(),
+		updated_at: z.iso.datetime(),
+	})
+	.passthrough();
+
+const invoiceSubscriptionSchema = z
+	.object({
 		status: z.string(),
 		subscription_code: z.string().startsWith("SUB_"),
 		email_token: z.string(),
@@ -399,103 +93,489 @@ export const subscriptionNotRenewed = z.object({
 		cron_expression: z.string(),
 		next_payment_date: z.iso.datetime(),
 		open_invoice: z.unknown().nullable(),
+	})
+	.passthrough();
+
+const invoiceSuccessTransactionSchema = z
+	.object({
+		reference: z.uuid(),
+		status: z.string(),
+		amount: z.number(),
+		currency,
+	})
+	.passthrough();
+
+const invoiceDataBaseSchema = z
+	.object({
+		domain: z.string(),
+		invoice_code: z.string().startsWith("INV_"),
+		amount: z.number(),
+		period_start: z.iso.datetime(),
+		period_end: z.iso.datetime(),
+		status: z.string(),
+		paid: z.boolean(),
+		paid_at: z.iso.datetime().nullable(),
+		description: z.string().nullable(),
+		authorization,
+		subscription: invoiceSubscriptionSchema,
+		customer: customer.omit({
+			international_format_phone: true,
+		}),
+	})
+	.passthrough();
+
+const paymentRequestDataSchema = z
+	.object({
+		id: z.number(),
+		domain: z.string(),
+		amount: z.number(),
+		currency,
+		due_date: z.iso.datetime().nullable(),
+		has_invoice: z.boolean(),
+		invoice_number: z.string().nullable(),
+		description: z.string().nullable(),
+		pdf_url: z.url().nullable(),
+		line_items: z.array(z.unknown()),
+		tax: z.array(z.unknown()),
+		request_code: z.string().startsWith("PRQ_"),
+		status: z.string(),
+		paid: z.boolean(),
+		paid_at: z.iso.datetime().nullable(),
+		metadata: z.nullable(metadata),
+		notifications: z.array(
+			z.object({
+				sent_at: z.iso.datetime(),
+				channel: z.string(),
+			}),
+		),
+		offline_reference: z.string().nullable(),
+		customer: z.number(),
+		created_at: z.iso.datetime(),
+	})
+	.passthrough();
+
+const refundDataBaseSchema = z
+	.object({
+		status: z.string(),
+		transaction_reference: z.string(),
+		amount: z.number(),
+		currency,
+		processor: z.string(),
+		customer: customer.pick({
+			first_name: true,
+			last_name: true,
+			email: true,
+		}),
 		integration: z.number(),
+		domain: z.string(),
+	})
+	.passthrough();
+
+const refundPendingOrProcessingDataSchema = refundDataBaseSchema
+	.extend({
+		refund_reference: z.string().startsWith("TRF_").nullable(),
+	})
+	.passthrough();
+
+const refundFailedOrProcessedDataSchema = refundDataBaseSchema
+	.extend({
+		refund_reference: z.string().startsWith("TRF_"),
+	})
+	.passthrough();
+
+const subscriptionCoreDataSchema = z
+	.object({
+		domain: z.string(),
+		status: z.string(),
+		subscription_code: z.string().startsWith("SUB_"),
+		amount: z.number(),
+		cron_expression: z.string(),
+		next_payment_date: z.iso.datetime(),
+		open_invoice: z.unknown().nullable(),
 		plan,
 		authorization: authorization.omit({
 			reusable: true,
 			signature: true,
 		}),
-		customer,
-		invoices: z.array(z.unknown()),
-		invoices_history: z.array(z.unknown()),
-		invoice_limit: z.number(),
-		split_code: z.string().nullable(),
-		most_recent_invoice: z.unknown().nullable(),
+		customer: customer.omit({
+			international_format_phone: true,
+			id: true,
+		}),
 		created_at: z.iso.datetime(),
-	}),
-});
+	})
+	.passthrough();
 
-export const subscriptionWithExpiredCard = z.object({
-	event: z.literal("subscription.expiring_cards"),
-	data: z.array(
-		z.object({
-			expiry_date: z.iso.datetime(),
-			description: z.string(),
-			brand: z.enum(["visa", "mastercard", "verve"]),
-			subscription: z.object({
-				id: z.number(),
-				subscription_code: z.string().startsWith("SUB_"),
-				amount: z.number(),
-				next_payment_date: z.iso.datetime(),
-				plan: plan.pick({
-					interval: true,
-					id: true,
-					name: true,
-					plan_code: true,
-				}),
-			}),
-			customer: customer.pick({
-				id: true,
-				first_name: true,
-				last_name: true,
-				email: true,
-				customer_code: true,
+const transferDataBaseSchema = z
+	.object({
+		amount: z.number(),
+		currency,
+		domain: z.string(),
+		failures: z.unknown().nullable(),
+		id: z.number(),
+		integration: z.object({
+			id: z.number(),
+			is_live: z.boolean(),
+			business_name: z.string(),
+		}),
+		reason: z.string(),
+		reference: z.string(),
+		source: z.string(),
+		source_details: z.unknown().nullable(),
+		status: z.string(),
+		titan_code: z.string().nullable(),
+		transfer_code: z.string().startsWith("TRF_"),
+		transferred_at: z.iso.datetime().nullable(),
+		session: z.object({
+			provider: z.string().nullable(),
+			id: z.string().nullable(),
+		}),
+		created_at: z.iso.datetime(),
+		updated_at: z.iso.datetime(),
+	})
+	.passthrough();
+
+const baseRecipientSchema = z
+	.object({
+		active: z.boolean(),
+		currency,
+		description: z.string(),
+		domain: z.string(),
+		email: z.email().nullable(),
+		id: z.number(),
+		integration: z.number(),
+		metadata: z.nullable(metadata),
+		name: z.string(),
+		recipient_code: z.string().startsWith("RCP_"),
+		type: z.string(),
+		is_deleted: z.boolean(),
+		created_at: z.iso.datetime(),
+		updated_at: z.iso.datetime(),
+	})
+	.passthrough();
+
+const transferSuccessRecipientSchema = baseRecipientSchema
+	.extend({
+		details: z.object({
+			account_number: z.string(),
+			account_name: z.string().nullable(),
+			bank_code: z.string(),
+			bank_name: z.string(),
+		}),
+	})
+	.passthrough();
+
+const transferFailedOrReversedRecipientSchema = baseRecipientSchema
+	.extend({
+		details: z.object({
+			account_number: z.string(),
+			account_name: z.string().nullable(),
+			bank_code: z.string(),
+			bank_name: z.string(),
+			authorization_code: z.string().startsWith("AUTH_").nullable(),
+		}),
+	})
+	.passthrough();
+
+const identificationBaseSchema = z
+	.object({
+		country: z.enum(["NG", "GH"]),
+		type: z.string(),
+	})
+	.passthrough();
+
+const customerDataBaseSchema = z
+	.object({
+		customer_id: z.string(),
+		customer_code: z.string().startsWith("CUS_"),
+		email: z.email(),
+	})
+	.passthrough();
+
+export const customerIdFail = z
+	.object({
+		event: z.literal("customeridentification.failed"),
+		data: customerDataBaseSchema.extend({
+			identification: identificationBaseSchema.extend({
+				bvn: z.string(),
+				account_number: z.string(),
+				bank_code: z.string(),
 			}),
 		}),
-	),
-});
+		reason: z.string(),
+	})
+	.passthrough();
 
-export const transactionSuccessful = z.object({
-	event: z.literal("charge.success"),
-	data: transactionShared
-		.omit({
-			receipt_number: true,
-			paidAt: true,
-			createdAt: true,
-		})
-		.extend({
-			log: log
-				.omit({
-					start_time: true,
-				})
-				.extend({
-					authentication: z.string(),
-				}),
-			metadata: metadata,
-			paid_at: z.iso.datetime(),
+export const customerIdSuccess = z
+	.object({
+		event: z.literal("customeridentification.success"),
+		data: customerDataBaseSchema.extend({
+			identification: identificationBaseSchema.extend({
+				value: z.string(),
+			}),
+		}),
+	})
+	.passthrough();
+
+export const disputeCreated = z
+	.object({
+		event: z.literal("charge.dispute.create"),
+		data: disputeDataSchema,
+	})
+	.passthrough();
+
+export const disputeReminder = z
+	.object({
+		event: z.literal("charge.dispute.remind"),
+		data: disputeDataSchema,
+	})
+	.passthrough();
+
+export const disputeResolved = z
+	.object({
+		event: z.literal("charge.dispute.resolve"),
+		data: disputeDataSchema,
+	})
+	.passthrough();
+
+export const dedicatedAccountAssignFail = z
+	.object({
+		event: z.literal("dedicatedaccount.assign.failed"),
+		data: z.object({
+			customer,
+			dedicated_account: z.unknown().nullable(),
+			identification: z.object({
+				status: z.string(),
+			}),
+		}),
+	})
+	.passthrough();
+
+export const dedicatedAccountAssignSuccess = z
+	.object({
+		event: z.literal("dedicatedaccount.assign.success"),
+		data: z.object({
+			customer,
+			dedicated_account: virtualAccountBaseSchema,
+			assignment: virtualAccountAssignmentSchema.extend({
+				expired_at: z.iso.datetime().nullable(),
+			}),
+		}),
+		identification: z.object({
+			status: z.string(),
+		}),
+	})
+	.passthrough();
+
+export const invoiceCreate = z
+	.object({
+		event: z.literal("invoice.create"),
+		data: invoiceDataBaseSchema.extend({
+			transaction: invoiceSuccessTransactionSchema,
 			created_at: z.iso.datetime(),
-			fees: z.number().nullable(),
-			customer: customer.omit({
-				international_format_phone: true,
-				id: true,
-			}),
-			authorization: authorization.omit({
-				signature: true,
-				reusable: true,
-			}),
 		}),
-});
+	})
+	.passthrough();
 
-export const transferSuccess = z.object({
-	event: z.literal("transfer.success"),
-	data: transferDataBaseSchema.extend({
-		recipient: transferSuccessRecipientSchema,
-	}),
-});
+export const invoiceFail = z
+	.object({
+		event: z.literal("invoice.payment_failed"),
+		data: invoiceDataBaseSchema.extend({
+			transaction: invoiceSuccessTransactionSchema.partial(),
+			created_at: z.iso.datetime(),
+		}),
+	})
+	.passthrough();
 
-export const transferFailed = z.object({
-	event: z.literal("transfer.failed"),
-	data: transferDataBaseSchema.extend({
-		recipient: transferFailedOrReversedRecipientSchema,
-	}),
-});
+export const invoiceUpdate = z
+	.object({
+		event: z.literal("invoice.update"),
+		data: invoiceDataBaseSchema.extend({
+			transaction: invoiceSuccessTransactionSchema,
+		}),
+	})
+	.passthrough();
 
-export const transferReversed = z.object({
-	event: z.literal("transfer.reversed"),
-	data: transferDataBaseSchema.extend({
-		recipient: transferFailedOrReversedRecipientSchema,
-	}),
-});
+export const paymentRequestPending = z
+	.object({
+		event: z.literal("paymentrequest.pending"),
+		data: paymentRequestDataSchema,
+	})
+	.passthrough();
+
+export const paymentRequestSuccess = z
+	.object({
+		event: z.literal("paymentrequest.success"),
+		data: paymentRequestDataSchema,
+	})
+	.passthrough();
+
+export const refundFailed = z
+	.object({
+		event: z.literal("refund.failed"),
+		data: refundFailedOrProcessedDataSchema,
+	})
+	.passthrough();
+
+export const refundPending = z
+	.object({
+		event: z.literal("refund.pending"),
+		data: refundPendingOrProcessingDataSchema,
+	})
+	.passthrough();
+
+export const refundProcessed = z
+	.object({
+		event: z.literal("refund.processed"),
+		data: refundFailedOrProcessedDataSchema,
+	})
+	.passthrough();
+
+export const refundProcessing = z
+	.object({
+		event: z.literal("refund.processing"),
+		data: refundPendingOrProcessingDataSchema,
+	})
+	.passthrough();
+
+export const subscriptionCreate = z
+	.object({
+		event: z.literal("subscription.create"),
+		data: subscriptionCoreDataSchema.extend({
+			createdAt: z.iso.datetime(),
+		}),
+	})
+	.passthrough();
+
+export const subscriptionDisabled = z
+	.object({
+		event: z.literal("subscription.disable"),
+		data: subscriptionCoreDataSchema.extend({
+			email_token: z.string(),
+		}),
+	})
+	.passthrough();
+
+export const subscriptionNotRenewed = z
+	.object({
+		event: z.literal("subscription.not_renew"),
+		data: z.object({
+			id: z.number(),
+			domain: z.string(),
+			status: z.string(),
+			subscription_code: z.string().startsWith("SUB_"),
+			email_token: z.string(),
+			amount: z.number(),
+			cron_expression: z.string(),
+			next_payment_date: z.iso.datetime(),
+			open_invoice: z.unknown().nullable(),
+			integration: z.number(),
+			plan,
+			authorization: authorization.omit({
+				reusable: true,
+				signature: true,
+			}),
+			customer,
+			invoices: z.array(z.unknown()),
+			invoices_history: z.array(z.unknown()),
+			invoice_limit: z.number(),
+			split_code: z.string().nullable(),
+			most_recent_invoice: z.unknown().nullable(),
+			created_at: z.iso.datetime(),
+		}),
+	})
+	.passthrough();
+
+export const subscriptionWithExpiredCard = z
+	.object({
+		event: z.literal("subscription.expiring_cards"),
+		data: z.array(
+			z.object({
+				expiry_date: z.iso.datetime(),
+				description: z.string(),
+				brand: z.enum(["visa", "mastercard", "verve"]),
+				subscription: z.object({
+					id: z.number(),
+					subscription_code: z.string().startsWith("SUB_"),
+					amount: z.number(),
+					next_payment_date: z.iso.datetime(),
+					plan: plan.pick({
+						interval: true,
+						id: true,
+						name: true,
+						plan_code: true,
+					}),
+				}),
+				customer: customer.pick({
+					id: true,
+					first_name: true,
+					last_name: true,
+					email: true,
+					customer_code: true,
+				}),
+			}),
+		),
+	})
+	.passthrough();
+
+export const transactionSuccessful = z
+	.object({
+		event: z.literal("charge.success"),
+		data: transactionShared
+			.omit({
+				receipt_number: true,
+				paidAt: true,
+				createdAt: true,
+			})
+			.extend({
+				log: log
+					.omit({
+						start_time: true,
+					})
+					.extend({
+						authentication: z.string(),
+					}),
+				metadata: metadata,
+				paid_at: z.iso.datetime(),
+				created_at: z.iso.datetime(),
+				fees: z.number().nullable(),
+				customer: customer.omit({
+					international_format_phone: true,
+					id: true,
+				}),
+				authorization: authorization.omit({
+					signature: true,
+					reusable: true,
+				}),
+			}),
+	})
+	.passthrough();
+
+export const transferSuccess = z
+	.object({
+		event: z.literal("transfer.success"),
+		data: transferDataBaseSchema.extend({
+			recipient: transferSuccessRecipientSchema,
+		}),
+	})
+	.passthrough();
+
+export const transferFailed = z
+	.object({
+		event: z.literal("transfer.failed"),
+		data: transferDataBaseSchema.extend({
+			recipient: transferFailedOrReversedRecipientSchema,
+		}),
+	})
+	.passthrough();
+
+export const transferReversed = z
+	.object({
+		event: z.literal("transfer.reversed"),
+		data: transferDataBaseSchema.extend({
+			recipient: transferFailedOrReversedRecipientSchema,
+		}),
+	})
+	.passthrough();
 
 export const paystackWebhookSchema = z.discriminatedUnion("event", [
 	customerIdFail,


### PR DESCRIPTION
When using the SDK in a Cloudflare Worker environment, a cryptic 'Unrecognized key: "id"' error was being thrown. This was caused by Zod's strict parsing of the API responses.

This change updates all Zod schemas for API responses to use `passthrough()`, which allows unrecognized keys in the response data. This makes the entire SDK more robust to changes in the Paystack API and resolves the issue reported in Cloudflare Workers and other environments.